### PR TITLE
fix: Exclude junit-jupiter-api:5.6.0 dep from testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,18 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>1.12.4</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>junit-jupiter-api</artifactId>
+                    <groupId>org.junit.jupiter</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.5.2</version>
+            <version>5.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This fixes #4 